### PR TITLE
fix `Alias=`

### DIFF
--- a/amd-disable-c6.service
+++ b/amd-disable-c6.service
@@ -9,5 +9,5 @@ Type=oneshot
 ExecStart=/usr/sbin/amd-disable-c6 --disable_c6_retry
 
 [Install]
-Alias=amd-disable-c6
+Alias=amd-disable-c6.service
 WantedBy=multi-user.target


### PR DESCRIPTION
The alias should have same suffix `.service` as the file. This commit add the suffix, which fixes the error
`Failed to enable unit: Cannot alias amd-disable-c6.service as amd-disable-c6`.

See also:

- https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#%5BInstall%5D%20Section%20Options
- https://unix.stackexchange.com/questions/788862/error-systemctl-failed-to-enable-unit-cannot-alias-service.

Fix #4.